### PR TITLE
feat: ICML 2022 Renzhe Xu

### DIFF
--- a/index.html
+++ b/index.html
@@ -529,8 +529,8 @@
     </li>
     
     <li>
-        Why Stable Learning Works? A Theory of Covariate Shift Generalization.
-        Renzhe Xu, Peng Cui, Zheyan Shen, Xingxuan Zhang, Tong Zhang <a href="https://arxiv.org/abs/2111.02355">(paper)</a>
+        A Theoretical Analysis on Independence-driven Importance Weighting for Covariate-shift Generalization.
+        Renzhe Xu, Xingxuan Zhang, Zheyan Shen, Tong Zhang, Peng Cui (ICML 2022) <a href="https://arxiv.org/abs/2111.02355">(paper)</a>
     </li>
 </ul>
 


### PR DESCRIPTION
Add the ICML 2022 paper "A Theoretical Analysis on Independence-driven Importance Weighting for Covariate-shift Generalization".